### PR TITLE
Changes increasing total stats to state_class: total_increasing

### DIFF
--- a/givtcp.yaml
+++ b/givtcp.yaml
@@ -19,52 +19,52 @@ template:
       - name: "GivTCP Import Energy Total"
         unit_of_measurement: "kWh"
         device_class: energy
-        state_class: measurement
+        state_class: total_increasing
         state: "{{ state_attr('sensor.givtcp','Energy')['Total']['Import_Energy_Total_kWh'] }}"
       - name: "GivTCP Export Energy Total"
         unit_of_measurement: "kWh"
         device_class: energy
-        state_class: measurement
+        state_class: total_increasing
         state: "{{ state_attr('sensor.givtcp','Energy')['Total']['Export_Energy_Total_kWh'] }}"
       - name: "GivTCP Battery Throughput Total"
         unit_of_measurement: "kWh"
         device_class: energy
-        state_class: measurement
+        state_class: total_increasing
         state: "{{ state_attr('sensor.givtcp','Energy')['Total']['Battery_Throughput_Total_kWh'] }}"
       - name: "GivTCP AC Charge Energy Total"
         unit_of_measurement: "kWh"
         device_class: energy
-        state_class: measurement
+        state_class: total_increasing
         state: "{{ state_attr('sensor.givtcp','Energy')['Total']['AC_Charge_Energy_Total_kWh'] }}"
       - name: "GivTCP Invertor Energy Total"
         unit_of_measurement: "kWh"
         device_class: energy
-        state_class: measurement
+        state_class: total_increasing
         state: "{{ state_attr('sensor.givtcp','Energy')['Total']['Invertor_Energy_Total_kWh'] }}"
       - name: "GivTCP PV Energy Total"
         unit_of_measurement: "kWh"
         device_class: energy
-        state_class: measurement
+        state_class: total_increasing
         state: "{{ state_attr('sensor.givtcp','Energy')['Total']['PV_Energy_Total_kWh'] }}"
       - name: "GivTCP Load Energy Total"
         unit_of_measurement: "kWh"
         device_class: energy
-        state_class: measurement
+        state_class: total_increasing
         state: "{{ state_attr('sensor.givtcp','Energy')['Total']['Load_Energy_Total_kWh'] }}"
       - name: "GivTCP Battery Charge Energy Total"
         unit_of_measurement: "kWh"
         device_class: energy
-        state_class: measurement
+        state_class: total_increasing
         state: "{{ state_attr('sensor.givtcp','Energy')['Total']['Battery_Charge_Energy_Total_kWh'] }}"
       - name: "GivTCP Battery Discharge Energy Total"
         unit_of_measurement: "kWh"
         device_class: energy
-        state_class: measurement
+        state_class: total_increasing
         state: "{{ state_attr('sensor.givtcp','Energy')['Total']['Battery_Discharge_Energy_Total_kWh'] }}"
       - name: "GivTCP Self Consumption Energy Total"
         unit_of_measurement: "kWh"
         device_class: energy
-        state_class: measurement
+        state_class: total_increasing
         state: "{{ state_attr('sensor.givtcp','Energy')['Total']['Self_Consumption_Energy_Total_kWh'] }}"
 
 


### PR DESCRIPTION
In order to use the sensor data in the "Energy" dashboard in Home Assistant, the total increasing stats need to be marked as `state_class: total_increasing` - otherwise the energy dashboard doesn't show anything.

<img width="855" alt="image" src="https://user-images.githubusercontent.com/110954/160467633-0e958fa8-f6a2-42d2-953f-268ceefeaa05.png">

See https://community.home-assistant.io/t/solved-energy-dashboard-stopped-working-with-upgrade-to-2022-2-0/388035/7