### PR TITLE
Replacing hard-coded IP with HOSTIP env var

### DIFF
--- a/GivTCP/GivLUT.py
+++ b/GivTCP/GivLUT.py
@@ -6,7 +6,8 @@ class GivClient:
 class GivQueue:
     from redis import Redis
     from rq import Connection, Queue
-    redis_connection = Redis(host='192.168.2.10', port=6379, db=0)
+    from os import getenv
+    redis_connection = Redis(host=getenv('HOSTIP'), port=6379, db=0)
     q = Queue(connection=redis_connection)
 
 class GEType:


### PR DESCRIPTION
When attempting to run the britkat/giv_tcp-dev:2022.09.09 image, I encountered the following issue:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/redis/connection.py", line 611, in connect
    sock = self.retry.call_with_retry(
  File "/usr/local/lib/python3.10/site-packages/redis/retry.py", line 46, in call_with_retry
    return do()
  File "/usr/local/lib/python3.10/site-packages/redis/connection.py", line 612, in <lambda>
    lambda: self._connect(), lambda error: self.disconnect(error)
  File "/usr/local/lib/python3.10/site-packages/redis/connection.py", line 677, in _connect
    raise err
  File "/usr/local/lib/python3.10/site-packages/redis/connection.py", line 665, in _connect
    sock.connect(socket_address)
OSError: [Errno 113] Host is unreachable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/app/GivTCP_1/read.py", line 876, in <module>
    globals()[sys.argv[1]]()
  File "/app/GivTCP_1/read.py", line 553, in self_run2
    runAll("True")
  File "/app/GivTCP_1/read.py", line 523, in runAll
    result=GivQueue.q.enqueue(getData,full_refresh)
  File "/usr/local/lib/python3.10/site-packages/rq/queue.py", line 515, in enqueue
    return self.enqueue_call(
  File "/usr/local/lib/python3.10/site-packages/rq/queue.py", line 413, in enqueue_call
    return self.enqueue_job(job, pipeline=pipeline, at_front=at_front)
  File "/usr/local/lib/python3.10/site-packages/rq/queue.py", line 573, in enqueue_job
    job.save(pipeline=pipe)
  File "/usr/local/lib/python3.10/site-packages/rq/job.py", line 689, in save
    if self.get_redis_server_version() >= (4, 0, 0):
  File "/usr/local/lib/python3.10/site-packages/rq/job.py", line 697, in get_redis_server_version
    self.redis_server_version = get_version(self.connection)
  File "/usr/local/lib/python3.10/site-packages/rq/utils.py", line 280, in get_version
    return tuple(int(i) for i in connection.info("server")["redis_version"].split('.')[:3])
  File "/usr/local/lib/python3.10/site-packages/redis/commands/core.py", line 972, in info
    return self.execute_command("INFO", section, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/redis/client.py", line 1235, in execute_command
    conn = self.connection or pool.get_connection(command_name, **options)
  File "/usr/local/lib/python3.10/site-packages/redis/connection.py", line 1387, in get_connection
    connection.connect()
  File "/usr/local/lib/python3.10/site-packages/redis/connection.py", line 617, in connect
    raise ConnectionError(self._error_message(e))
redis.exceptions.ConnectionError: Error 113 connecting to 192.168.2.10:6379. Host is unreachable.
```

It looks like the address 192.168.2.10 was a hard-coded reference to your own setup; replaced with the HOSTIP environment variable. 