### PR TITLE
Cutoff/Reserve Entity Fix

### DIFF
--- a/GivTCP/GivLUT.py
+++ b/GivTCP/GivLUT.py
@@ -2,13 +2,13 @@ class GivClient:
     def getData(fullrefresh):
         from givenergy_modbus.client import GivEnergyClient
         from settings import GiV_Settings
-        from givenergy_modbus.model.plant import Plant  
-        
+        from givenergy_modbus.model.plant import Plant
+
         client= GivEnergyClient(host=GiV_Settings.invertorIP)
         plant=Plant(number_batteries=int(GiV_Settings.numBatteries))
         client.refresh_plant(plant,full_refresh=fullrefresh)
         return (plant)
-        
+
 class GivQueue:
     from redis import Redis
     from rq import Queue
@@ -75,7 +75,7 @@ class GivLUT:
     maxCost=100
     maxRate=2
     Last_Updated_Time=GEType("sensor","timestamp","","","",False,False,False)
-    
+
     entity_type={
         "Last_Updated_Time":GEType("sensor","timestamp","","","",False,False,False),
         "Time_Since_Last_Update":GEType("sensor","","",0,10000,True,False,False),
@@ -175,6 +175,7 @@ class GivLUT:
         "Battery_Cell_4_Temperature":GEType("sensor","temperature","",-maxTemp,maxTemp,True,True,False),
         "Mode":GEType("select","","setBatteryMode","","",False,False,False),
         "Battery_Power_Reserve":GEType("number","","setBatteryReserve",4,100,False,False,False),
+        "Battery_Power_Cutoff":GEType("number","","setBatteryCutoff",4,100,False,False,False),
         "Target_SOC":GEType("number","","setChargeTarget",4,100,False,False,False),
         "Enable_Charge_Schedule":GEType("switch","","enableChargeSchedule","","",False,False,False),
         "Enable_Discharge_Schedule":GEType("switch","","enableDishargeSchedule","","",False,False,False),
@@ -225,7 +226,7 @@ class GivLUT:
 "22:00:00","22:01:00","22:02:00","22:03:00","22:04:00","22:05:00","22:06:00","22:07:00","22:08:00","22:09:00","22:10:00","22:11:00","22:12:00","22:13:00","22:14:00","22:15:00","22:16:00","22:17:00","22:18:00","22:19:00","22:20:00","22:21:00","22:22:00","22:23:00","22:24:00","22:25:00","22:26:00","22:27:00","22:28:00","22:29:00","22:30:00","22:31:00","22:32:00","22:33:00","22:34:00","22:35:00","22:36:00","22:37:00","22:38:00","22:39:00","22:40:00","22:41:00","22:42:00","22:43:00","22:44:00","22:45:00","22:46:00","22:47:00","22:48:00","22:49:00","22:50:00","22:51:00","22:52:00","22:53:00","22:54:00","22:55:00","22:56:00","22:57:00","22:58:00","22:59:00",
 "23:00:00","23:01:00","23:02:00","23:03:00","23:04:00","23:05:00","23:06:00","23:07:00","23:08:00","23:09:00","23:10:00","23:11:00","23:12:00","23:13:00","23:14:00","23:15:00","23:16:00","23:17:00","23:18:00","23:19:00","23:20:00","23:21:00","23:22:00","23:23:00","23:24:00","23:25:00","23:26:00","23:27:00","23:28:00","23:29:00","23:30:00","23:31:00","23:32:00","23:33:00","23:34:00","23:35:00","23:36:00","23:37:00","23:38:00","23:39:00","23:40:00","23:41:00","23:42:00","23:43:00","23:44:00","23:45:00","23:46:00","23:47:00","23:48:00","23:49:00","23:50:00","23:51:00","23:52:00","23:53:00","23:54:00","23:55:00","23:56:00","23:57:00","23:58:00","23:59:00"
     ]
-    
+
     delay_times=["Normal","Running","2","15","30","45","60","90","120","150","180"]
     modes=["Eco","Timed Demand","Timed Export","Unknown", "Eco (Paused)"]
 

--- a/GivTCP/GivLUT.py
+++ b/GivTCP/GivLUT.py
@@ -57,6 +57,7 @@ class GivLUT:
     lastupdate=GiV_Settings.cache_location+"/lastUpdate_"+str(GiV_Settings.givtcp_instance)+".pkl"
     forcefullrefresh=GiV_Settings.cache_location+"/.forceFullRefresh_"+str(GiV_Settings.givtcp_instance)
     batterypkl=GiV_Settings.cache_location+"/battery_"+str(GiV_Settings.givtcp_instance)+".pkl"
+    reservepkl=GiV_Settings.cache_location+"/reserve_"+str(GiV_Settings.givtcp_instance)+".pkl"
     ppkwhtouch=".ppkwhtouch"
     schedule=".schedule"
     oldDataCount=GiV_Settings.cache_location+"/oldDataCount_"+str(GiV_Settings.givtcp_instance)+".pkl"
@@ -256,6 +257,8 @@ class GivLUT:
                 os.remove(GivLUT.batterypkl)
             if exists(GivLUT.oldDataCount):
                 os.remove(GivLUT.oldDataCount)
+            if exists(GivLUT.reservepkl):
+                os.remove(GivLUT.reservepkl)
         else:
             with open(GivLUT.oldDataCount, 'wb') as outp:
                 pickle.dump(oldDataCount, outp, pickle.HIGHEST_PROTOCOL)

--- a/GivTCP/mqtt_client.py
+++ b/GivTCP/mqtt_client.py
@@ -37,7 +37,7 @@ while not hasattr(GiV_Settings,'serial_number'):
     if count==20:
         logger.error("No serial_number found in MQTT queue. MQTT Control not available.")
         break
-    
+
 logger.info("Serial Number retrieved: "+GiV_Settings.serial_number)
 
 def on_message(client, userdata, message):
@@ -67,8 +67,12 @@ def on_message(client, userdata, message):
         writecommand['chargeToPercent']=str(message.payload.decode("utf-8"))
         result=GivQueue.q.enqueue(wr.setChargeTarget,writecommand)
     elif command=="setBatteryReserve":
-        writecommand['dischargeToPercent']=str(message.payload.decode("utf-8"))
+        #writecommand['dischargeToPercent']=str(message.payload.decode("utf-8"))
+        writecommand['reservePercent']=str(message.payload.decode("utf-8"))
         result=GivQueue.q.enqueue(wr.setBatteryReserve,writecommand)
+    elif command=="setBatteryCutoff":
+        writecommand['dischargeToPercent']=str(message.payload.decode("utf-8"))
+        result=GivQueue.q.enqueue(wr.setBatteryCutoff,writecommand)
     elif command=="setBatteryMode":
         writecommand['mode']=str(message.payload.decode("utf-8"))
         result=GivQueue.q.enqueue(wr.setBatteryMode,writecommand)

--- a/GivTCP/write.py
+++ b/GivTCP/write.py
@@ -79,9 +79,10 @@ def setShallowCharge(payload):
 
 def enableDischarge(payload):
     temp={}
+    saved_battery_reserve = getSavedBatteryReservePercentage()
     try:
         if payload['state']=="enable":
-            client.set_shallow_charge(4)
+            client.set_shallow_charge(saved_battery_reserve)
         elif payload['state']=="disable":
             client.set_shallow_charge(100)
         temp['result']="Setting Discharge Enable was a success"
@@ -458,6 +459,8 @@ def setBatteryMode(payload):
     try:
         if payload['mode']=="Eco":
             client.set_mode_dynamic()
+            time.sleep(1)
+            client.set_shallow_charge(getSavedBatteryReservePercentage())
         elif payload['mode']=="Eco (Paused)":
             client.set_mode_dynamic()
             time.sleep(1)
@@ -498,6 +501,15 @@ def setDateTime(payload):
         temp['result']="Setting Battery Mode failed: " + str(e)
         logger.error (temp['result'])
     return json.dumps(temp)
+
+def getSavedBatteryReservePercentage():
+    saved_battery_reserve=4
+    if exists(GivLUT.reservepkl):
+        with open(GivLUT.reservepkl, 'rb') as inp:
+            saved_battery_reserve= pickle.load(inp)
+    return saved_battery_reserve
+
+
 
 if __name__ == '__main__':
     if len(sys.argv)==2:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Once this has been done the container should start-up and begin publishing data 
 
 From here your invertor data is available through either MQTT or REST as described below. 
 
-### Docker Envirnoment Variables
+### Docker Environment Variables
 
 | ENV Name                | Example       |  Description                      |
 | ----------------------- | ------------- |  -------------------------------- |


### PR DESCRIPTION
The reserve SOC entity now reads and writes the reserve SOC register.
A new cutoff SOC entity reads and writes the cutoff register (which was previously controlled by the reserve entity).
Eco mode detection is now based on reserve != 100% instead of == 4%.

To-do:
Pausing and resuming Eco mode resets the reserve SOC back to 4%.
Need a way to store the user's preferred reserve %age (so any non-100 value that is ever configured either in GivTCP or read from the register) within GivTCP and restore that value instead of the hard coded 4.
Setting eco mode is currently achieved by calling client.set_mode_dynamic. This third party library is hard coded to reset to 4% so instead we must make separate calls for:
client.set_discharge_mode_to_match_demand()
client.set_shallow_charge(whatever_saved_reserve_value_we_have)
client.disable_discharge()
I'm not sure of the best way to do that so advice is needed!
