### PR TITLE
Add datetime sensor class for Invertor Time sensor

### DIFF
--- a/GivTCP/GivLUT.py
+++ b/GivTCP/GivLUT.py
@@ -148,7 +148,7 @@ class GivLUT:
         "Battery_Type":GEType("sensor","string","","","",False,False,False),
         "Battery_Capacity_kWh":GEType("sensor","","",0,maxBatPower,True,True,False),
         "Invertor_Serial_Number":GEType("sensor","string","","","",False,False,False),
-        "Invertor_Time":GEType("sensor","","","","",False,False,False),
+        "Invertor_Time":GEType("sensor","datetime","","","",False,False,False),
         "Invertor_Max_Rate":GEType("sensor","","",0,maxBatPower,True,False,False),
         "Active_Power_Rate":GEType("number","","setActivePowerRate",0,100,True,False,False),
         "Invertor_Firmware":GEType("sensor","string","",0,10000,False,False,False),

--- a/GivTCP/HA_Discovery.py
+++ b/GivTCP/HA_Discovery.py
@@ -155,6 +155,8 @@ class HAMQTT():
             if GivLUT.entity_type[str(topic).split("/")[-1]].sensorClass=="timestamp":
                 del(tempObj['unit_of_meas'])
                 tempObj['device_class']="timestamp"
+            if GivLUT.entity_type[str(topic).split("/")[-1]].sensorClass=="datetime":
+                del(tempObj['unit_of_meas'])
             if GivLUT.entity_type[str(topic).split("/")[-1]].sensorClass=="string":
                 del(tempObj['unit_of_meas'])
                 tempObj['device_class']="enum"


### PR DESCRIPTION
This appears to fix the error with the Invetor Time sensor on HA 2023.05.x. It adds another sensor class (datetime) and just removes the `unit_of_meas` field from the HA autodiscovery.