### PR TITLE
Remove enum device class from string sensors

### DIFF
--- a/GivTCP/HA_Discovery.py
+++ b/GivTCP/HA_Discovery.py
@@ -157,7 +157,6 @@ class HAMQTT():
                 tempObj['device_class']="timestamp"
             if GivLUT.entity_type[str(topic).split("/")[-1]].sensorClass=="string":
                 del(tempObj['unit_of_meas'])
-                tempObj['device_class']="enum"
         elif GivLUT.entity_type[str(topic).split("/")[-1]].devType=="switch":
             tempObj['payload_on']="enable"
             tempObj['payload_off']="disable"


### PR DESCRIPTION
Previous fix was incorrect from reading the HA docs. enum sensor type should only be used if we give it a list of all the possible options. This could work for Battery, Meter and Invertor types, but isn't correct for firmware versions.

Removing the `unit_of_meas` attribute from the HA auto discovery fixes the issue.