### PR TITLE
Update palm_soc.py

### DIFF
--- a/GivTCP/palm_settings.py
+++ b/GivTCP/palm_settings.py
@@ -68,7 +68,7 @@ class Solcast:
     
     # For single array installation uncomment the line below and comment out the subsequent line
     #url_sw = ""
-    if not str(os.getenv('SOLCASTSITEID2')).strip():
+    if str(os.getenv('SOLCASTSITEID2')).strip() != "":
         url_sw = "https://api.solcast.com.au/rooftop_sites/"+str(os.getenv('SOLCASTSITEID2'))
     else:
         url_sw = ""

--- a/GivTCP/palm_soc.py
+++ b/GivTCP/palm_soc.py
@@ -473,7 +473,7 @@ class SolcastObj:
             print("Error; Problem reading Solcast data, using previous values (if any)")
             return
 
-        if stgs.Solcast.url_sw:  # Two arrays are specified
+        if stgs.Solcast.url_sw != "":  # Two arrays are specified
             logger.info("url_sw = '"+str(stgs.Solcast.url_sw)+"'")
             result, solcast_data_2 = get_solcast(stgs.Solcast.url_sw)
             if not result:

--- a/GivTCP/palm_soc.py
+++ b/GivTCP/palm_soc.py
@@ -489,7 +489,7 @@ class SolcastObj:
         pv_est50 = [0] * 10080
         pv_est90 = [0] * 10080
 
-        if stgs.Solcast.url_sw:  # Two arrays are specified
+        if stgs.Solcast.url_sw != "":  # Two arrays are specified
             forecast_lines = min(len(solcast_data_1['forecasts']), len(solcast_data_2['forecasts']))
         else:
             forecast_lines = len(solcast_data_1['forecasts'])
@@ -501,7 +501,7 @@ class SolcastObj:
         index = solcast_offset
         cntr = 0
         while index < forecast_lines * interval:
-            if stgs.Solcast.url_sw:  # Two arrays are specified
+            if stgs.Solcast.url_sw != "":  # Two arrays are specified
                 pv_est10[index] = (int(solcast_data_1['forecasts'][cntr]['pv_estimate10'] * 1000) +
                     int(solcast_data_2['forecasts'][cntr]['pv_estimate10'] * 1000))
                 pv_est50[index] = (int(solcast_data_1['forecasts'][cntr]['pv_estimate'] * 1000) +


### PR DESCRIPTION
Fixed single site detection again - the latest updates to align palm_soc broke it. You can't just make sure a setting exists because it always exists in the add-on sadly, you have to actually check that the string isn't an empty string for the url_sw variable otherwise it tries to execute and returns a dud URL breaking the solar forecasting and always setting it to 100%