### PR TITLE
Fix Upper Charge Limit % Toggle

### DIFF
--- a/GivTCP/write.py
+++ b/GivTCP/write.py
@@ -23,7 +23,7 @@ logger = GivLUT.logger
 def sct(target):
     temp={}
     try:
-        client.set_battery_target_soc(target)
+        client.enable_charge_target(target)
         temp['result']="Setting Charge Target was a success"
         logger.info(temp['result'])
     except:


### PR DESCRIPTION
Latest update broke setting the SOC target - inverter would ignore limit because ENABLE_CHARGE_TARGET was never called. Recent change was updated to call client.set_battery_target_soc(target) which doesn't toggle ENABLE_CHARGE_TARGET. Calling client.enable_charge_target(target) instead does. Not sure why the change was made so the reason may need to be investigated in case the change to client.set_battery_target_soc(target) was intentional to fix something else?