### PR TITLE
Define SuperTimezone and set to false if not running as Add On.

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -49,6 +49,7 @@ except:
     logger.critical("SUPERVISOR TOKEN does not exist")
     isAddon=False
     hasMQTT=False
+    SuperTimezone=False
 
 if isAddon:
     #Get MQTT Details    


### PR DESCRIPTION
Should fix #93. SuperTimezone is not defined unless the isAddon if statement is run. This causes a NameError Exception when the code is not running under Supervisor.

While it would be possible to put "if SuperTimezone: outp.write(" timezone=""+str(SuperTimezone)+""\n")" in a try->catch block or under another if statement, it's better to have a predefined variable to avoid the exception altogether. Setting it to false should allow your if statement to work as intended.