### PR TITLE
Enable long term stats

### DIFF
--- a/GivTCP/HA_Discovery.py
+++ b/GivTCP/HA_Discovery.py
@@ -143,18 +143,23 @@ class HAMQTT():
             if GivLUT.entity_type[str(topic).split("/")[-1]].sensorClass=="temperature":
                 tempObj['unit_of_meas']="°C"
                 tempObj['device_class']="Temperature"
+                tempObj['state_class']="measurement"
             if GivLUT.entity_type[str(topic).split("/")[-1]].sensorClass=="voltage":
                 tempObj['unit_of_meas']="V"
                 tempObj['device_class']="Voltage"
+                tempObj['state_class']="measurement"
             if GivLUT.entity_type[str(topic).split("/")[-1]].sensorClass=="frequency":
                 tempObj['unit_of_meas']="Hz"
                 tempObj['device_class']="frequency"
+                tempObj['state_class']="measurement"
             if GivLUT.entity_type[str(topic).split("/")[-1]].sensorClass=="current":
                 tempObj['unit_of_meas']="A"
                 tempObj['device_class']="Current"
+                tempObj['state_class']="measurement"
             if GivLUT.entity_type[str(topic).split("/")[-1]].sensorClass=="battery":
                 tempObj['unit_of_meas']="%"
                 tempObj['device_class']="Battery"
+                tempObj['state_class']="measurement"
             if GivLUT.entity_type[str(topic).split("/")[-1]].sensorClass=="timestamp":
                 del(tempObj['unit_of_meas'])
                 tempObj['device_class']="timestamp"

--- a/GivTCP/HA_Discovery.py
+++ b/GivTCP/HA_Discovery.py
@@ -131,7 +131,7 @@ class HAMQTT():
                     tempObj['state_class']="total_increasing"
             if GivLUT.entity_type[str(topic).split("/")[-1]].sensorClass=="money":
                 if "ppkwh" in str(topic).lower() or "rate" in str(topic).lower():
-                   tempObj['unit_of_meas']="{GBP}/kWh"
+                    tempObj['unit_of_meas']="{GBP}/kWh"
                 else:
                     tempObj['unit_of_meas']="{GBP}"
                 tempObj['device_class']="Monetary"


### PR DESCRIPTION
Add support for HA long term statistics by labelling entities with state_class = measurement. 

Resolves #98. This allows use of the statistics card with HA by adding the [required attribute](https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics).

I've experienced high grid voltage causing reduced (or no) generation with no alerting or feedback to indicate this is the cause. This allows greater visibility of the metrics reported by GivTCP.

I have this running locally with the PALM fixes in my fork.