### PR TITLE
Fix time parse

### DIFF
--- a/givenergy_modbus/model/register.py
+++ b/givenergy_modbus/model/register.py
@@ -45,7 +45,13 @@ class Type(Enum):
 
         if self == self.TIME:
             # Convert a BCD-encoded int into datetime.time."""
-            return time(hour=int(f'{value:04}'[:2]), minute=int(f'{value:04}'[2:]) % 60)
+            hour = int(f'{value:04}'[:2])
+            minute = int(f'{value:04}'[2:])
+            if hour == 24:
+                hour = 0
+            if minute == 60:
+                minute = 0
+            return time(hour, minute)
 
         if self == self.ASCII:
             return value.to_bytes(2, byteorder='big').decode(encoding='ascii')


### PR DESCRIPTION
This appears to fix my issue where I'd get serial number errors. After figuring this out and writing the code myself it turns out it was also fixed on the modbus library - https://github.com/dewet22/givenergy-modbus/commit/2b6cb3cff68485bc264956e5ad68db00da66f0b5