### PR TITLE
Updates for WebDashboard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add redis
 RUN apk add nginx
 
 RUN mkdir -p /run/nginx
-RUN npm install -g serve
+RUN npm install -g http-server
 
 # set the working directory in the container
 WORKDIR /app
@@ -43,6 +43,6 @@ COPY redis.conf redis.conf
 COPY settings.json ./settings.json
 COPY ingress/ ./ingress
 
-EXPOSE 1883 6379 8099
+EXPOSE 1883 3000 6379 8099
 
 CMD ["python3", "/app/startup.py"]

--- a/startup.py
+++ b/startup.py
@@ -625,7 +625,7 @@ if setts['Web_Dash']==True:
         outp.write("}")
     WDPORT=int(setts['Web_Dash_Port'])
     logger.info ("Serving Web Dashboard from port "+str(WDPORT))
-    command=shlex.split("/usr/bin/node /usr/local/bin/serve -p "+ str(WDPORT))
+    command=shlex.split("/usr/bin/node /usr/local/bin/http-server -p "+ str(WDPORT))
     webDash=subprocess.Popen(command)
 
 
@@ -678,7 +678,7 @@ while True:
                 os.chdir("/app/WebDashboard")
                 WDPORT = int(setts['Web_Dash_Port'])
                 logger.info("Serving Web Dashboard from port " + str(WDPORT))
-                command = shlex.split("/usr/bin/node /usr/local/bin/serve -p " + str(WDPORT))
+                command = shlex.split("/usr/bin/node /usr/local/bin/http-server -p " + str(WDPORT))
                 webDash = subprocess.Popen(command)
 
         if setts['MQTT_Address']=="127.0.0.1":


### PR DESCRIPTION
- Replaces the `serve` npm module with `http-server` (to resolve the `punycode` error in `serve` -  https://github.com/vercel/serve/issues/802).
- Points the WebDashboard folder to the most recent commit (it was previously pointing to an outdated/nonexistent version of the web dashboard).