### PR TITLE
Correctly yield Exception for invalid frame

### DIFF
--- a/GivTCP/givenergy_modbus_async/pdu/base.py
+++ b/GivTCP/givenergy_modbus_async/pdu/base.py
@@ -95,8 +95,8 @@ class BasePDU(ABC):
             pdu.ensure_valid_state()
         except InvalidPduState:
             raise
-        # except Exception as e:
-        #     raise InvalidFrame(str(e), data)
+        except Exception as e:
+            raise InvalidFrame(str(e), data)
 
         if not decoder.decoding_complete:
             _logger.error(


### PR DESCRIPTION
Issue: https://github.com/britkat1980/giv_tcp/issues/273

Re-add the wrapping of exceptions raised during frame decoding to `InvalidFrame`. This ensures that the async `framer.decode` correctly yields the exception instead of raising it directly, which causes `client._task_network_consumer` to terminate silently.