### PR TITLE
Dockerfile: disable package caches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@
 #FROM python:3.11-rc-alpine
 FROM python:alpine3.19
 
-RUN apk add mosquitto
-RUN apk add npm 
-RUN apk add git 
-RUN apk add tzdata 
-RUN apk add musl 
-RUN apk add xsel 
-RUN apk add redis
-RUN apk add nginx
+RUN apk add --no-cache \
+    git \
+    mosquitto \
+    musl \
+    nginx \
+    redis \
+    tzdata \
+    xsel
 
 RUN mkdir -p /run/nginx
 RUN npm install -g http-server
@@ -19,7 +19,7 @@ WORKDIR /app
 
 # copy the dependencies file to the working directory
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir
 
 COPY givtcp-vuejs/package.json /app/ingress/package.json
 


### PR DESCRIPTION
Disables the packages cache for apk and pip. This shaves ~100MB from the resultant image.

The apk package additions have also been combined into a single layer, as it's more efficient.

This should be rebased on #283; I thought a distinct PR would be easier to review.