### PR TITLE
parse microseconds if they come in

### DIFF
--- a/GivTCP/read.py
+++ b/GivTCP/read.py
@@ -761,7 +761,11 @@ def processInverterInfo(plant: Plant):
         else:
             # Use latest data if its not default date
             inverter['Invertor_Time'] = GEInv.system_time.replace(tzinfo=GivLUT.timezone).isoformat()
-        inv_time=datetime.datetime.strptime(inverter['Invertor_Time'], '%Y-%m-%dT%H:%M:%S%z')
+        try:
+            inv_time=datetime.datetime.strptime(inverter['Invertor_Time'], '%Y-%m-%dT%H:%M:%S%z')
+        except ValueError:
+            # isoformat() adds a .<microseconds> in so try parsing that
+            inv_time=datetime.datetime.strptime(inverter['Invertor_Time'], '%Y-%m-%dT%H:%M:%S.%f%z')
 
     ############  Energy Stats    ############
         # Total Energy Figures


### PR DESCRIPTION
I started getting this kinds of stuff in my GivTCP logs:


```2024-12-31 03:36:18,020 - GivTCP - read        -  [ERROR   ] - inverter Update failed so using last known good data from cache: ((<class 'ValueError'>, ValueError("time data '2024-12-31T03:36:17.981419+00:00' does not match format '%Y-%m-%dT%H:%M:%S%z'"), <traceback object at 0x7fb0dd77c0>), 1687)```