### PR TITLE
force isoformat to provide no microseconds so parsing works

### DIFF
--- a/GivTCP/read.py
+++ b/GivTCP/read.py
@@ -757,10 +757,10 @@ def processInverterInfo(plant: Plant):
             inverter['Invertor_Time'] = finditem(multi_output_old,"Invertor_Time")
             if inverter['Invertor_Time']==None:
             # Unless its missing then use now()
-                inverter['Invertor_Time']=datetime.datetime.now(GivLUT.timezone).isoformat()
+                inverter['Invertor_Time']=datetime.datetime.now(GivLUT.timezone).isoformat(timespec='seconds')
         else:
             # Use latest data if its not default date
-            inverter['Invertor_Time'] = GEInv.system_time.replace(tzinfo=GivLUT.timezone).isoformat()
+            inverter['Invertor_Time'] = GEInv.system_time.replace(tzinfo=GivLUT.timezone).isoformat(timespec='seconds')
         inv_time=datetime.datetime.strptime(inverter['Invertor_Time'], '%Y-%m-%dT%H:%M:%S%z')
 
     ############  Energy Stats    ############
@@ -1434,10 +1434,10 @@ def processThreePhaseInfo(plant: Plant):
             inverter['Invertor_Time'] = finditem(multi_output_old,"Invertor_Time")
             if inverter['Invertor_Time']==None:
             # Unless its missing then use now()
-                inverter['Invertor_Time']=datetime.datetime.now(GivLUT.timezone).isoformat()
+                inverter['Invertor_Time']=datetime.datetime.now(GivLUT.timezone).isoformat(timespec='seconds')
         else:
             # Use latest data if its not default date
-            inverter['Invertor_Time'] = GEInv.system_time.replace(tzinfo=GivLUT.timezone).isoformat()
+            inverter['Invertor_Time'] = GEInv.system_time.replace(tzinfo=GivLUT.timezone).isoformat(timespec='seconds')
         inv_time=datetime.datetime.strptime(inverter['Invertor_Time'], '%Y-%m-%dT%H:%M:%S%z')
 
     #    if GiV_Settings.Print_Raw_Registers:


### PR DESCRIPTION
I started getting this kinds of stuff in my GivTCP logs:

```
2024-12-31 03:36:18,020 - GivTCP - read        -  [ERROR   ] - inverter Update failed so using last known good data from cache: ((<class 'ValueError'>, ValueError("time data '2024-12-31T03:36:17.981419+00:00' does not match format '%Y-%m-%dT%H:%M:%S%z'"), <traceback object at 0x7fb0dd77c0>), 1687)
```

This PR forces the value string to not have microseconds