### PR TITLE
Fix time format in readme for charge and discharge slots

### DIFF
--- a/ingress/readme.html
+++ b/ingress/readme.html
@@ -134,27 +134,27 @@
     </tr>
     <tr>
     <td>setChargeSlot1</td>
-    <td>Sets   the time and target SOC of the first chargeslot. Times must be expressed in   hhmm format. Enable flag show in the battery.api documentation is not needed   and chargeToPercent is optional</td>
+    <td>Sets   the time and target SOC of the first chargeslot. Times must be expressed in   hh:mm format. Enable flag show in the battery.api documentation is not needed   and chargeToPercent is optional</td>
     <td>/setChargeSlot1</td>
-    <td>{&quot;start&quot;:&quot;0100&quot;,&quot;finish&quot;:&quot;0400&quot;,&quot;chargeToPercent&quot;:&quot;55&quot;}</td>
+    <td>{&quot;start&quot;:&quot;01:00&quot;,&quot;finish&quot;:&quot;04:00&quot;,&quot;chargeToPercent&quot;:&quot;55&quot;}</td>
     <td>setChargeSlot1</td>
-    <td>{&quot;start&quot;:&quot;0100&quot;,&quot;finish&quot;:&quot;0400&quot;,&quot;chargeToPercent&quot;:&quot;55&quot;}</td>
+    <td>{&quot;start&quot;:&quot;01:00&quot;,&quot;finish&quot;:&quot;04:00&quot;,&quot;chargeToPercent&quot;:&quot;55&quot;}</td>
     </tr>
     <tr>
     <td>setDischargeSlot1</td>
-    <td>Sets   the time and target SOC of the first dischargeslot. Times must be expressed   in hhmm format. Enable flag show in the battery.api documentation is not   needed and dischargeToPercent is optional</td>
+    <td>Sets   the time and target SOC of the first dischargeslot. Times must be expressed   in hh:mm format. Enable flag show in the battery.api documentation is not   needed and dischargeToPercent is optional</td>
     <td>/setDischargeSlot1</td>
-    <td>{&quot;start&quot;:&quot;0100&quot;,&quot;finish&quot;:&quot;0400&quot;,&quot;dischargeToPercent&quot;:&quot;55&quot;}</td>
+    <td>{&quot;start&quot;:&quot;01:00&quot;,&quot;finish&quot;:&quot;04:00&quot;,&quot;dischargeToPercent&quot;:&quot;55&quot;}</td>
     <td>setDischargeSlot1</td>
-    <td>{&quot;start&quot;:&quot;0100&quot;,&quot;finish&quot;:&quot;0400&quot;,&quot;dischargeToPercent&quot;:&quot;55&quot;}</td>
+    <td>{&quot;start&quot;:&quot;01:00&quot;,&quot;finish&quot;:&quot;04:00&quot;,&quot;dischargeToPercent&quot;:&quot;55&quot;}</td>
     </tr>
     <tr>
     <td>setDischargeSlot2</td>
-    <td>Sets   the time and target SOC of the first dischargeslot. Times must be expressed   in hhmm format. Enable flag show in the battery.api documentation is not   needed and dischargeToPercent is optional</td>
+    <td>Sets   the time and target SOC of the first dischargeslot. Times must be expressed   in hh:mm format. Enable flag show in the battery.api documentation is not   needed and dischargeToPercent is optional</td>
     <td>/setDischargeSlot2</td>
-    <td>{&quot;start&quot;:&quot;0100&quot;,&quot;finish&quot;:&quot;0400&quot;,&quot;dischargeToPercent&quot;:&quot;55&quot;}</td>
+    <td>{&quot;start&quot;:&quot;01:00&quot;,&quot;finish&quot;:&quot;04:00&quot;,&quot;dischargeToPercent&quot;:&quot;55&quot;}</td>
     <td>setDischargeSlot2</td>
-    <td>{&quot;start&quot;:&quot;0100&quot;,&quot;finish&quot;:&quot;0400&quot;,&quot;dischargeToPercent&quot;:&quot;55&quot;}</td>
+    <td>{&quot;start&quot;:&quot;01:00&quot;,&quot;finish&quot;:&quot;04:00&quot;,&quot;dischargeToPercent&quot;:&quot;55&quot;}</td>
     </tr>
     <tr>
     <td>setBatteryMode</td>


### PR DESCRIPTION
Updated time format from hhmm to hh:mm in documentation as hhmm causes an error