### PR TITLE
fix: Correct Smart_Target mapping in generated runtime settings

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -145,7 +145,7 @@ def createsettingsjson(inv):
         outp.write("    Debug_File_Location=\"/config/GivTCP/logs/log_inv_"+str(inv)+".log\"\n")
         outp.write("    Debug_File_Location_Write=\"/config/GivTCP/logs/write_log_inv_"+str(inv)+".log\"\n")
         outp.write("    inverter_num=\""+str(inv)+"\"\n")
-        outp.write("    Smart_Target="+str(setts["dynamic_tariff"]).capitalize()+"\n")
+        outp.write("    Smart_Target="+str(setts["Smart_Target"]).capitalize()+"\n")
         outp.write("    GE_API=\""+str(setts["GE_API"])+"\"\n")
         outp.write("    PALM_WINTER=\""+str(setts["PALM_WINTER"])+"\"\n")
         outp.write("    PALM_SHOULDER=\""+str(setts["PALM_SHOULDER"])+"\"\n")


### PR DESCRIPTION
This is part of a small series of minor PRs that address reliability issues encountered while developing an extension module for `giv_tcp` in a Docker deployment without MQTT/Home Assistant. These PRs are intended to improve robustness of existing behaviour and do not add new user-facing functionality.

The related PRs are: #540, #541

Each PR is intentionally mergeable on its own and does not depend on the related PRs.

This PR fixes the generated runtime settings so that `Smart_Target` is populated from the `Smart_Target` config value rather than `dynamic_tariff`.

Current behaviour:
- `Smart_Target` in generated settings is incorrectly written from `dynamic_tariff`

Effect:
- any logic that depends on `Smart_Target` in runtime settings will see the wrong value

Change:
- write `Smart_Target` from `setts["Smart_Target"]`

This PR is intentionally narrow and changes only `startup.py`.