### PR TITLE
fix: Resolve site-packages path dynamically in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,11 @@ RUN rm /etc/nginx/http.d/default.conf
 COPY GivTCP/ ./GivTCP
 COPY WebDashboard ./WebDashboard
 # COPY givenergy_modbus/ /usr/local/lib/python3.11/site-packages/givenergy_modbus
-COPY GivTCP/givenergy_modbus_async/ /usr/local/lib/python3.12/site-packages/givenergy_modbus_async
+COPY GivTCP/givenergy_modbus_async/ /tmp/givenergy_modbus_async
+RUN SITE_PACKAGES=$(python3 -c "import site; print(site.getsitepackages()[0])") && \
+    mkdir -p "${SITE_PACKAGES}" && \
+    cp -r /tmp/givenergy_modbus_async "${SITE_PACKAGES}/givenergy_modbus_async" && \
+    rm -rf /tmp/givenergy_modbus_async
 
 COPY api.json ./GivTCP/api.json
 COPY startup.py startup.py


### PR DESCRIPTION
This is part of a small series of minor PRs that address reliability issues encountered while developing an extension module for `giv_tcp` in a Docker deployment without MQTT/Home Assistant. These PRs are intended to improve robustness of existing behaviour and do not add new user-facing functionality.

The other PRs are: #539, #541

Each PR is intentionally mergeable on its own and does not depend on the related PRs.

This PR makes the Docker build resolve the Python site-packages path dynamically before installing `givenergy_modbus_async`.

Current behaviour:
- the Dockerfile copies `givenergy_modbus_async` into a hard-coded Python 3.12 site-packages path

Effect:
- the build can break or install incorrectly if the image Python version/site-packages path differs

Change:
- copy the package to a temporary location
- resolve the active site-packages directory with Python at build time
- copy the package into that resolved path

This PR is intentionally narrow and changes only `Dockerfile`.