### PR TITLE
fix: Avoid blocking MQTT writes when MQTT output is unavailable

### DIFF
--- a/GivTCP/mqtt.py
+++ b/GivTCP/mqtt.py
@@ -43,6 +43,14 @@ class GivMQTT():
     else:
         MQTT_Topic=GiV_Settings.MQTT_Topic
 
+    def _wait_for_connection(max_wait_seconds=2.0):
+        waited = 0.0
+        while not _mqttclient.connected_flag and waited < max_wait_seconds:
+            logger.debug("Waiting for MQTT connection")
+            time.sleep(0.2)
+            waited += 0.2
+        return _mqttclient.connected_flag
+
     def get_connection():
         try:
             global _mqttclient
@@ -60,6 +68,7 @@ class GivMQTT():
         except:
             e=sys.exc_info()[0].__name__, basename(sys.exc_info()[2].tb_frame.f_code.co_filename), sys.exc_info()[2].tb_lineno
             logger.error("Error getting connection to MQTT Broker: " + str(e))
+            return None
 
     def isfloat(num):
         try:
@@ -85,23 +94,28 @@ class GivMQTT():
     def single_MQTT_publish(Topic,value):   #Recieve multiple payloads with Topics and publish in a single MQTT connection
         client=GivMQTT.get_connection()
         try:
-            while not _mqttclient.connected_flag:        			#wait in loop
-                #GivMQTT.connect()
-                logger.debug ("In wait loop (single_MQTT_publish)")
-                time.sleep(0.2)
+            if not client:
+                logger.debug("Skipping MQTT publish because broker connection could not be established")
+                return
+            if not GivMQTT._wait_for_connection():
+                logger.warning("Skipping MQTT publish because broker did not become ready in time")
+                return
             client.publish(Topic,value)
         except:
             e=sys.exc_info()[0].__name__, basename(sys.exc_info()[2].tb_frame.f_code.co_filename), sys.exc_info()[2].tb_lineno
             logger.error("Error connecting to MQTT Broker: " + str(e))
-            GivMQTT.client.disconnect()
+            client.disconnect()
 #            GivMQTT.client.loop_stop()                      			    #Stop loop
 
     def multi_MQTT_publish(rootTopic,array):                    #Recieve multiple payloads with Topics and publish in a single MQTT connection
         client=GivMQTT.get_connection()
         try:
-            while not _mqttclient.connected_flag:        			#wait in loop
-                logger.debug ("In wait loop (multi_MQTT_publish)")
-                time.sleep(0.2)
+            if not client:
+                logger.debug("Skipping MQTT publish because broker connection could not be established")
+                return
+            if not GivMQTT._wait_for_connection():
+                logger.warning("Skipping MQTT publish because broker did not become ready in time")
+                return
             for p_load in array:
                 payload=array[p_load]
                 logger.debug('Publishing: '+rootTopic+p_load)

--- a/GivTCP/write.py
+++ b/GivTCP/write.py
@@ -72,8 +72,11 @@ def updateControlCache(entity,value,isTime: bool=False):
         value=value.split(" ")[1]
     else:
         Topic=str(GiV_Settings.MQTT_Topic+"/"+GiV_Settings.serial_number+"/Control/")+str(entity)
-    logger.debug("Pushing control update to mqtt: "+Topic+" - "+str(value))
-    GivMQTT.single_MQTT_publish(Topic,str(value))
+    if GiV_Settings.MQTT_Output:
+        logger.debug("Pushing control update to mqtt: "+Topic+" - "+str(value))
+        GivMQTT.single_MQTT_publish(Topic,str(value))
+    else:
+        logger.debug("Skipping MQTT control update because MQTT_Output is disabled")
 
     # now update the pkl cache file
     if exists(GivLUT.regcache):      # if there is a cache then grab it


### PR DESCRIPTION
This is part of a small series of minor PRs that address reliability issues encountered while developing an extension module for `giv_tcp` in a Docker deployment without MQTT/Home Assistant. These PRs are intended to improve robustness of existing behaviour and do not add new user-facing functionality.

The other PRs are: #539, #540

Each PR is intentionally mergeable on its own and does not depend on the related PRs.

This PR makes control-cache and MQTT publish behaviour fail fast when MQTT output is disabled or a broker connection cannot be established.

Current behaviour:
- control updates always attempt MQTT publish from `write.py`
- `mqtt.py` waits in connection loops that can block when no broker is available or MQTT output is not in use

Effect:
- write paths can stall or behave poorly in deployments where MQTT is disabled or unavailable

Change:
- only publish control updates when `MQTT_Output` is enabled
- return early if MQTT connection setup fails
- bound the wait for MQTT readiness before publish
- skip publish cleanly if the broker never becomes ready

This PR is intentionally narrow and changes only `GivTCP/mqtt.py` and `GivTCP/write.py`.