### PR TITLE
fix: avoid stale cached config html asset mismatch

### DIFF
--- a/ingress.conf
+++ b/ingress.conf
@@ -50,6 +50,15 @@ server {
     location /rq/ {
         proxy_pass http://127.0.0.1:9181/;
     }
+    location = /config.html {
+        add_header Cache-Control "no-store, no-cache, must-revalidate, max-age=0" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
+        try_files $uri =404;
+    }
+    location /assets/ {
+        try_files $uri =404;
+    }
     location / {
         index index.html;
         try_files $uri $uri/ /index.html;

--- a/ingress_no_ssl.conf
+++ b/ingress_no_ssl.conf
@@ -45,6 +45,15 @@ server {
     location /rq/ {
         proxy_pass http://127.0.0.1:9181/;
     }
+    location = /config.html {
+        add_header Cache-Control "no-store, no-cache, must-revalidate, max-age=0" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
+        try_files $uri =404;
+    }
+    location /assets/ {
+        try_files $uri =404;
+    }
     location / {
         index index.html;
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## Summary

When doing dev work on the config UI, I have been encountering problems in Chrome with it failing to display the config.html content and instead just the top standard content  of [device URI]:8099 is displayed. This is not happening in other browsers (Firefox, Safari). An incognito window in Chrome does not encounter this problem, and in a regular Chrome window if I go to Developer Tools > Network reload and look at the page assets then they are displayed properly. This is consistent with a caching issue in Chrome. 

This patch changes the ingress config for the config UI to reduce the chance of a blank `config.html` page after frontend updates.

The likely failure mode is:
- a browser keeps a cached copy of 'config.html'
- the config UI build produces new hashed asset filenames
- the cached HTML points at an old '/assets/...' bundle
- the missing asset falls through to the generic HTML route instead of returning a clean '404'
- the config UI does not render until cache is bypassed

This patch applies the same mitigation to both ingress configs:
- `ingress_no_ssl.conf`
- `ingress.conf`

## Changes

- add a dedicated `location = /config.html`
- send `Cache-Control: no-store, no-cache, must-revalidate, max-age=0`
- add `Pragma: no-cache` and `Expires: 0`
- add a dedicated `location /assets/`
- return `404` for missing assets instead of falling through to `/index.html`

## Scope

This PR is intentionally narrow:
- ingress-only
- no frontend logic changes
- no build pipeline changes

## Testing

Not fully reproducible on demand, but behaviour is consistent with a cache-related issue:
- blank page reproduced in normal Chrome
- page loaded in Incognito
- page loaded after forced reload in Chrome Developer Tools

This patch has not yet been validated by broader user reports, so it should be considered a targeted mitigation for the suspected cache/asset mismatch path.

## Risk

Low. The change is limited to config UI caching and asset routing behavior.

Main behaviour change:
- missing `/assets/*` files now return `404` rather than falling through to the HTML entrypoint