### PR TITLE
fix: constrain pymodbus to 2.x (EV charger support only)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ flask-cors
 rq
 redis
 npm
-pymodbus
+pymodbus<3
 async_timeout
 vite
 tzdata


### PR DESCRIPTION
SUMMARY: In this repo, pymodbus is used exclusively for EV charger support 
(details below). It is currently unpinned in requirements.txt. pymodbus 3.0.0 makes
major changes, and removes pymodbus.client.sync which is required by the EV 
charger code. Any build using pymodbus 3.x therefore fails. To resolve this, 
pin pymodbus to <3.

SCOPE: pymodbus is used exclusively for EV charger support. The only two places
that import it are GivTCP/evc.py and validateEVC() in startup.py. Inverter 
communication does not use pymodbus at all - that goes through the
givenergy_modbus_async library - so nothing here touches the inverter path.

PROBLEM: requirements.txt leaves pymodbus unpinned, so a fresh image build
currently resolves 3.x, which removed pymodbus.client.sync - startup.py:

    File "/app/startup.py", line 14, in <module>
        from pymodbus.client.sync import ModbusTcpClient
    ModuleNotFoundError: No module named 'pymodbus.client.sync'

SOLUTION: Constrain to <3 to allow for 2.x patch releases. This currently 
resolves to 2.5.3, and restores a clean startup.
