### PR TITLE
fix: make the dashboard link work without Home Assistant

### DIFF
--- a/ingress/header.html
+++ b/ingress/header.html
@@ -4,7 +4,7 @@
     <p>Manage your energy system efficiently.</p>
     <span id="config"><a href="config.html" target="_self">Go to Config Page</a></span>
     <span id="readme"><a href="readme.html" target="_self">Go to Readme Page</a></span>
-    <span id="dashboard"><a href="http://homeassistant.local:8099/dashboard" target="_blank">View Dashboard</a></span>
+    <span id="dashboard"><a href="dashboard/" target="_blank">View Dashboard</a></span>
 </div>
 <script> 
     await fetch('hostip.json').then(response => {


### PR DESCRIPTION
ingress/header.html hardcoded the dashboard link to
http://homeassistant.local:8099/dashboard. On a standalone install that host
does not resolve, so "View Dashboard" is a dead link.

Use a relative link instead, matching the sibling "config.html" and
"readme.html" links, so it resolves against whatever origin served the page.

The trailing slash is deliberate: nginx defines the proxy as
"location /dashboard/", and while a request for /dashboard is redirected, that
301 carries an absolute Location built from the Host header. Linking straight
to dashboard/ avoids the redirect entirely.

Testing: verified against a standalone install, where the link now resolves to
<host>:8099/dashboard/ and returns the dashboard. 

IMPORTANT NOTE: NOT verified under Home Assistant ingress, as I have no
HA instance to test against -- that path needschecking before merge. The 
relative form should resolve under the ingress prefix, but note that 
updateurl() in index.html, readme.html and the config page separately 
rewrites this link at runtime to an absolute
http://<hostip>:8099/dashboard, which may exist deliberately so that
target="_blank" escapes the ingress iframe. Those call sites are left
untouched here.