### PR TITLE
feat(config-ui): make the setup page usable on portrait mobile

### DIFF
--- a/givtcp-vuejs/src/components/Setup.vue
+++ b/givtcp-vuejs/src/components/Setup.vue
@@ -1,6 +1,16 @@
 <template>
   <div>
-    <v-timeline direction="horizontal" align="start" side="end">
+    <!--
+      Section navigation and the step actions stay put while the form scrolls,
+      so switching section or saving never requires scrolling back up.
+    -->
+    <div class="gtcp-sticky-nav">
+    <v-timeline
+      v-if="!$vuetify.display.smAndDown"
+      direction="horizontal"
+      align="start"
+      side="end"
+    >
       <v-timeline-item
         v-for="(timeline, i) in timelineList"
         :key="i"
@@ -19,18 +29,60 @@
         </div>
       </v-timeline-item>
     </v-timeline>
+    <!--
+      Narrow screens: the horizontal timeline neither wraps nor scrolls, so it
+      needs as much width as all the section labels combined. In portrait that
+      is not available and the labels become unreadable. Wrapping chips use the
+      width that is available and keep every section visible and one tap away.
+    -->
+    <v-chip-group v-else column class="px-3 pt-3">
+      <!-- Step -1 is the welcome page, which has no entry in timelineList. -->
+      <v-chip
+        size="small"
+        :color="storeStep.step === -1 ? '#4fbba9' : undefined"
+        :variant="storeStep.step === -1 ? 'flat' : 'outlined'"
+        @click="storeStep.step = -1"
+      >
+        Welcome
+      </v-chip>
+      <v-chip
+        v-for="(timeline, i) in timelineList"
+        :key="i"
+        size="small"
+        :color="i === storeStep.step ? '#4fbba9' : undefined"
+        :variant="i === storeStep.step ? 'flat' : 'outlined'"
+        :style="{ textTransform: timeline === 'evc' ? 'uppercase' : 'capitalize' }"
+        @click="storeStep.step = i"
+      >
+        {{ timeline === 'homeAssistant' ? 'Home Assistant' : timeline }}
+      </v-chip>
+    </v-chip-group>
+      <div class="d-flex flex-1-1-100 justify-center py-2">
+        <StepButton />
+      </div>
+    </div>
     <v-container>
       <h1 class="text-center" v-if="storeStep.step === -1">
         Welcome to the GivTCP setup page
       </h1>
-      <h2 class="text-center" v-if="storeStep.step === -1">
-        This config page is where you are able to tweak the configuration of GivTCP to suit your needs. <br>
-        GivTCP will add in any inverters it finds into the inverters page, but you are able to tweak them as needed.<br>
-        The first time you run this you will need to check the details then turn on "Self Run" to start GivTCP.<br>
-        You need to restart GivTCP after making any changes to the configuration.<br>
-      </h2>
-      <div class="d-flex flex-1-1-100 justify-center ma-5">
-        <StepButton />
+      <!--
+        Body copy, so paragraphs rather than a heading full of <br> tags: as an
+        h2 this rendered at heading size, which is overwhelming on a phone.
+        base.css zeroes margins on everything, hence the explicit mb-4.
+      -->
+      <div class="text-center" v-if="storeStep.step === -1">
+        <p class="mb-4">
+          This config page is where you are able to tweak the configuration of GivTCP to suit your needs.
+        </p>
+        <p class="mb-4">
+          GivTCP will add in any inverters it finds into the inverters page, but you are able to tweak them as needed.
+        </p>
+        <p class="mb-4">
+          The first time you run this you will need to check the details then turn on "Self Run" to start GivTCP.
+        </p>
+        <p>
+          You need to restart GivTCP after making any changes to the configuration.
+        </p>
       </div>
       <FormCard v-if="storeStep.step >= 0" :card="storeCard[timelineList[storeStep.step]]" />
     </v-container>
@@ -65,4 +117,19 @@ export default {
 }
 </script>
 
-<style scoped></style>
+<style scoped>
+.gtcp-sticky-nav {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  /*
+    Match the page itself rather than Vuetify's theme variables: with no v-app
+    wrapper the Vuetify theme is fixed to light, so --v-theme-background stays
+    white even in dark mode. These are the pair body uses in base.css, and they
+    flip together under prefers-color-scheme, keeping the chips legible in both.
+  */
+  background: var(--color-background);
+  color: var(--color-text);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+}
+</style>


### PR DESCRIPTION
The section navigation is a horizontal v-timeline, which neither wraps nor
scrolls. It therefore needs as much width as all the section labels combined,
and on a portrait phone that width does not exist, so the labels crush into
each other and become unreadable.

Below Vuetify's sm breakpoint, render the sections as a wrapping v-chip-group
instead. Every section stays visible and is one tap away, rather than needing
horizontal scrolling or repeated Next presses. The timeline is unchanged above
that breakpoint, so desktop rendering is identical.

Also:

- Add a Welcome chip. Step -1 is the welcome page but has no entry in
  timelineList, so previously the only way back was to open a section and press
  Previous.
- Keep the section navigation and the Previous/Save/Next actions pinned to the
  top while the form scrolls, so switching section or saving no longer requires
  scrolling back up. This moves the button row out of v-container, which is
  what lets it stay put.
- Put a blank line between the welcome page paragraphs, which currently run
  together.

The sticky header takes its colours from --color-background/--color-text in
assets/base.css rather than Vuetify's theme variables, because those flip with
prefers-color-scheme while Vuetify's are fixed to the light theme in the
absence of a v-app wrapper.